### PR TITLE
🔀 :: 공지 Feature Refresh 기능 추가

### DIFF
--- a/Projects/Feature/NoticeFeature/Tests/NoticeFeatureTest.swift
+++ b/Projects/Feature/NoticeFeature/Tests/NoticeFeatureTest.swift
@@ -72,7 +72,7 @@ final class NoticeFeatureTests: XCTestCase {
         .store(in: &subscription)
 
         XCTAssertEqual(fetchNoticeListUseCase.fetchNoticeListCallCount, 0)
-        sut.send(.viewWillAppear)
+        sut.send(.fetchNoticeList)
 
         wait(for: [expectation], timeout: 1.0)
         XCTAssertEqual(expected, sut.currentState.noticeList)

--- a/Projects/Feature/NoticeFeature/Tests/NoticeFeatureTest.swift
+++ b/Projects/Feature/NoticeFeature/Tests/NoticeFeatureTest.swift
@@ -66,7 +66,7 @@ final class NoticeFeatureTests: XCTestCase {
         ]
         fetchNoticeListUseCase.fetchNoticeListReturn = expected
 
-        sut.state.map(\.noticeList).sink { _ in
+        sut.state.map(\.noticeList).removeDuplicates().sink { _ in
             expectation.fulfill()
         }
         .store(in: &subscription)


### PR DESCRIPTION
## 💡 개요
<img src="https://github.com/Team-Ampersand/Dotori-iOS/assets/74440939/40a8da76-4f1f-47a5-8037-dbf11dbfb170" width="150" />

## 📃 작업내용
- 공지 리스트 tableView에 refresh 기능을 추가

## 🔀 변경사항
- viewWillAppear action -> fetchNoticeList action 이름 변경
