### PR TITLE
🔀 :: Domain 레이어에서 toEntity를 사용해 DomainEntity로 변환하는 메서드명 변경

### DIFF
--- a/Projects/Domain/MassageDomain/Sources/DTO/Response/FetchMassageInfoResponseDTO.swift
+++ b/Projects/Domain/MassageDomain/Sources/DTO/Response/FetchMassageInfoResponseDTO.swift
@@ -8,7 +8,7 @@ struct FetchMassageInfoResponseDTO: Decodable {
 }
 
 extension FetchMassageInfoResponseDTO {
-    func toEntity() -> MassageInfoEntity {
+    func toDomain() -> MassageInfoEntity {
         MassageInfoModel(count: count, limit: limit, massageStatus: massageStatus)
     }
 }

--- a/Projects/Domain/MassageDomain/Sources/DataSource/Remote/RemoteMassageDataSourceImpl.swift
+++ b/Projects/Domain/MassageDomain/Sources/DataSource/Remote/RemoteMassageDataSourceImpl.swift
@@ -13,7 +13,7 @@ final class RemoteMassageDataSourceImpl: RemoteMassageDataSource {
             MassageEndpoint.fetchMassageInfo,
             dto: FetchMassageInfoResponseDTO.self
         )
-        .toEntity()
+        .toDomain()
     }
 
     func applyMassage() async throws {

--- a/Projects/Domain/MealDomain/Sources/DataSource/Local/Entity/MealInfoLocalEntity.swift
+++ b/Projects/Domain/MealDomain/Sources/DataSource/Local/Entity/MealInfoLocalEntity.swift
@@ -25,7 +25,7 @@ struct MealInfoLocalEntity: Codable, FetchableRecord, PersistableRecord {
 }
 
 extension MealInfoLocalEntity {
-    func toDomainEntity() -> MealInfoEntity {
+    func toDomain() -> MealInfoEntity {
         MealInfoEntity(
             meals: meals,
             mealType: MealType(rawValue: mealType) ?? .breakfast

--- a/Projects/Domain/MealDomain/Sources/DataSource/Local/LocalMealDataSourceImpl.swift
+++ b/Projects/Domain/MealDomain/Sources/DataSource/Local/LocalMealDataSourceImpl.swift
@@ -31,7 +31,7 @@ final class LocalMealDataSourceImpl: LocalMealDataSource {
             as: MealInfoLocalEntity.self,
             filter: (dateStart...dateEnd).contains(Column("date"))
         )
-        .map { $0.toDomainEntity() }
+        .map { $0.toDomain() }
     }
 
     func saveMealInfoList(date: Date, mealInfoList: [MealInfoEntity]) throws {

--- a/Projects/Domain/MealDomain/Sources/DataSource/Remote/RemoteMealDataSourceImpl.swift
+++ b/Projects/Domain/MealDomain/Sources/DataSource/Remote/RemoteMealDataSourceImpl.swift
@@ -21,12 +21,12 @@ final class RemoteMealDataSourceImpl: RemoteMealDataSource {
         )
 
         return try await neis.fetchMealInfo(request: request)
-            .toEntity()
+            .toDomain()
     }
 }
 
 extension [MealInfoResponse] {
-    func toEntity() -> [MealInfoEntity] {
+    func toDomain() -> [MealInfoEntity] {
         self.map {
             MealInfoEntity(
                 meals: $0.DDISH_NM.components(separatedBy: "<br/>"),

--- a/Projects/Domain/NoticeDomain/Sources/DTO/Response/FetchNoticeListResponseDTO.swift
+++ b/Projects/Domain/NoticeDomain/Sources/DTO/Response/FetchNoticeListResponseDTO.swift
@@ -16,7 +16,7 @@ struct FetchNoticeListResponseDTO: Decodable {
 }
 
 extension FetchNoticeListResponseDTO.NoticeResponseDTO {
-    func toEntity() -> NoticeEntity {
+    func toDomain() -> NoticeEntity {
         .init(
             id: id,
             title: title,
@@ -28,8 +28,8 @@ extension FetchNoticeListResponseDTO.NoticeResponseDTO {
 }
 
 extension FetchNoticeListResponseDTO {
-    func toEntity() -> [NoticeEntity] {
+    func toDomain() -> [NoticeEntity] {
         self.boardList
-            .map { $0.toEntity() }
+            .map { $0.toDomain() }
     }
 }

--- a/Projects/Domain/NoticeDomain/Sources/DataSource/RemoteNoticeDataSourceImpl.swift
+++ b/Projects/Domain/NoticeDomain/Sources/DataSource/RemoteNoticeDataSourceImpl.swift
@@ -13,6 +13,6 @@ final class RemoteNoticeDataSourceImpl: RemoteNoticeDataSource {
             NoticeEndpoint.fetchNoticeList,
             dto: FetchNoticeListResponseDTO.self
         )
-        .toEntity()
+        .toDomain()
     }
 }

--- a/Projects/Domain/SelfStudyDomain/Sources/DTO/Response/FetchSelfStudyInfoResponseDTO.swift
+++ b/Projects/Domain/SelfStudyDomain/Sources/DTO/Response/FetchSelfStudyInfoResponseDTO.swift
@@ -8,7 +8,7 @@ struct FetchSelfStudyInfoResponseDTO: Decodable {
 }
 
 extension FetchSelfStudyInfoResponseDTO {
-    func toEntity() -> SelfStudyInfoEntity {
+    func toDomain() -> SelfStudyInfoEntity {
         SelfStudyInfoEntity(count: count, limit: limit, selfStudyStatus: selfStudyStatus)
     }
 }

--- a/Projects/Domain/SelfStudyDomain/Sources/DataSource/Remote/RemoteSelfStudyDataSourceImpl.swift
+++ b/Projects/Domain/SelfStudyDomain/Sources/DataSource/Remote/RemoteSelfStudyDataSourceImpl.swift
@@ -13,7 +13,7 @@ final class RemoteSelfStudyDataSourceImpl: RemoteSelfStudyDataSource {
             SelfStudyEndpoint.fetchSelfStudyInfo,
             dto: FetchSelfStudyInfoResponseDTO.self
         )
-        .toEntity()
+        .toDomain()
     }
 
     func applySelfStudy() async throws {


### PR DESCRIPTION
## 💡 개요
Domain 레이어에서 ResponseDTO, LocalEntity같은것을 DomainEntity로 변환할 때 .toEntity() 혹은 toDomainEntity()라는 메서드명으로 변환 작업을 했지만, toDomain()이라는 이름이 더 적절하다 판단되어 toDomain()으로 변경합니다

## 🔀 변경사항
- ResponseDTO들의 toEntity() 함수명을 toDomain()으로 변경
- MealInfoLocalEntity의 toDomainEntity() 함수명을 toDomain()으로 변경
