### PR TITLE
🔀 :: BaseViewController와 BaseStoredViewController 분리

### DIFF
--- a/Projects/Feature/BaseFeature/Sources/Base/BaseModalViewController.swift
+++ b/Projects/Feature/BaseFeature/Sources/Base/BaseModalViewController.swift
@@ -7,87 +7,33 @@ import UIKit
 /**
  addView() 메서드를 재정의할 때 꼭 super.addView()를 호출해주세요 !
  */
-open class BaseModalViewController<Store: BaseStore>:
-    UIViewController,
-    HasCancellableBag,
-    StoredViewControllable,
-    AddViewable,
-    SetLayoutable,
-    ViewControllerConfigurable,
-    NavigationConfigurable,
-    StoreBindable {
+open class BaseModalViewController: BaseViewController {
 
     // MARK: - Properties
 
-    private let viewDidLoadSubject = PassthroughSubject<Void, Never>()
-    private let viewWillAppearSubject = PassthroughSubject<Void, Never>()
-    private let viewDidAppearSubject = PassthroughSubject<Void, Never>()
-    private let viewWillDisappearSubject = PassthroughSubject<Void, Never>()
-    private let viewDidDisappearSubject = PassthroughSubject<Void, Never>()
-    public let store: Store
-    public var subscription = Set<AnyCancellable>()
     public var contentView = UIView()
         .set(\.alpha, 0)
-
-    // MARK: - Init
-
-    public init(store: Store) {
-        self.store = store
-        super.init(nibName: nil, bundle: nil)
-    }
-
-    required public init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
 
     // MARK: - LifeCycle
 
     open override func viewDidLoad() {
-        super.viewDidLoad()
         if UITraitCollection.current.userInterfaceStyle == .light {
             view.backgroundColor = .init(red: 0.02, green: 0.03, blue: 0.17, alpha: 0.45)
         } else {
             view.backgroundColor = .init(red: 0, green: 0, blue: 0, alpha: 0.45)
         }
-        addView()
-        setLayout()
-        configureViewController()
-        configureNavigation()
-        bindAction()
-        bindState()
-        viewDidLoadSubject.send(())
+        super.viewDidLoad()
     }
+
 
     open override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        viewWillAppearSubject.send(())
         modalAnimation()
     }
 
-    open override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        viewDidAppearSubject.send(())
-    }
-
-    open override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        viewWillDisappearSubject.send(())
-    }
-
-    open override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
-        viewDidDisappearSubject.send(())
-    }
-
-    open func addView() {
+    open override func addView() {
         view.addSubview(contentView)
     }
-
-    open func setLayout() {}
-
-    open func configureViewController() {}
-
-    open func configureNavigation() {}
 
     /**
      해당 method는 viewWillAppear에 실행됩니다
@@ -97,33 +43,5 @@ open class BaseModalViewController<Store: BaseStore>:
             .fadeIn(0.2),
             .dotoriDialog()
         ]))
-    }
-
-    open func bindState() {}
-
-    open func bindAction() {}
-}
-
-// MARK: - LifeCyclePublishable
-
-extension BaseModalViewController: LifeCyclePublishable {
-    public var viewDidLoadPublisher: AnyPublisher<Void, Never> {
-        viewDidLoadSubject.eraseToAnyPublisher()
-    }
-
-    public var viewWillAppearPublisher: AnyPublisher<Void, Never> {
-        viewWillAppearSubject.eraseToAnyPublisher()
-    }
-
-    public var viewDidAppearPublisher: AnyPublisher<Void, Never> {
-        viewDidAppearSubject.eraseToAnyPublisher()
-    }
-
-    public var viewWillDisappearPublisher: AnyPublisher<Void, Never> {
-        viewWillDisappearSubject.eraseToAnyPublisher()
-    }
-
-    public var viewDidDisappearPublisher: AnyPublisher<Void, Never> {
-        viewDidDisappearSubject.eraseToAnyPublisher()
     }
 }

--- a/Projects/Feature/BaseFeature/Sources/Base/BaseStoredModalViewController.swift
+++ b/Projects/Feature/BaseFeature/Sources/Base/BaseStoredModalViewController.swift
@@ -1,0 +1,41 @@
+import Anim
+import Combine
+import Configure
+import DesignSystem
+import UIKit
+
+/**
+ addView() 메서드를 재정의할 때 꼭 super.addView()를 호출해주세요 !
+ */
+open class BaseStoredModalViewController<Store: BaseStore>:
+    BaseModalViewController,
+    StoredViewControllable,
+    StoreBindable {
+
+    // MARK: - Properties
+
+    public let store: Store
+
+    // MARK: - Init
+
+    public init(store: Store) {
+        self.store = store
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required public init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - LifeCycle
+
+    open override func viewDidLoad() {
+        bindAction()
+        bindState()
+        super.viewDidLoad()
+    }
+
+    open func bindState() {}
+
+    open func bindAction() {}
+}

--- a/Projects/Feature/BaseFeature/Sources/Base/BaseStoredViewController.swift
+++ b/Projects/Feature/BaseFeature/Sources/Base/BaseStoredViewController.swift
@@ -1,0 +1,34 @@
+import UIKit
+
+open class BaseStoredViewController<Store: BaseStore>:
+    BaseViewController,
+    StoredViewControllable,
+    StoreBindable {
+
+    // MARK: - Properties
+
+    public let store: Store
+
+    // MARK: - Init
+
+    public init(store: Store) {
+        self.store = store
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required public init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - LifeCycle
+
+    open override func viewDidLoad() {
+        bindAction()
+        bindState()
+        super.viewDidLoad()
+    }
+
+    open func bindState() {}
+
+    open func bindAction() {}
+}

--- a/Projects/Feature/BaseFeature/Sources/Base/BaseViewController.swift
+++ b/Projects/Feature/BaseFeature/Sources/Base/BaseViewController.swift
@@ -2,15 +2,13 @@ import Combine
 import DesignSystem
 import UIKit
 
-open class BaseViewController<Store: BaseStore>:
+open class BaseViewController:
     UIViewController,
     HasCancellableBag,
-    StoredViewControllable,
     AddViewable,
     SetLayoutable,
     ViewControllerConfigurable,
-    NavigationConfigurable,
-    StoreBindable {
+    NavigationConfigurable {
 
     // MARK: - Properties
 
@@ -19,21 +17,7 @@ open class BaseViewController<Store: BaseStore>:
     private let viewDidAppearSubject = PassthroughSubject<Void, Never>()
     private let viewWillDisappearSubject = PassthroughSubject<Void, Never>()
     private let viewDidDisappearSubject = PassthroughSubject<Void, Never>()
-    public let store: Store
     public var subscription = Set<AnyCancellable>()
-
-    // MARK: - Init
-
-    public init(store: Store) {
-        self.store = store
-        super.init(nibName: nil, bundle: nil)
-    }
-
-    required public init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    // MARK: - LifeCycle
 
     open override func viewDidLoad() {
         super.viewDidLoad()
@@ -42,8 +26,6 @@ open class BaseViewController<Store: BaseStore>:
         setLayout()
         configureViewController()
         configureNavigation()
-        bindAction()
-        bindState()
         viewDidLoadSubject.send(())
     }
 
@@ -74,10 +56,6 @@ open class BaseViewController<Store: BaseStore>:
     open func configureViewController() {}
 
     open func configureNavigation() {}
-
-    open func bindState() {}
-
-    open func bindAction() {}
 }
 
 // MARK: - LifeCyclePublishable

--- a/Projects/Feature/ConfirmationDialogFeature/Sources/Scene/ConfirmationDialogViewController.swift
+++ b/Projects/Feature/ConfirmationDialogFeature/Sources/Scene/ConfirmationDialogViewController.swift
@@ -7,7 +7,7 @@ import Localization
 import MSGLayout
 import UIKit
 
-final class ConfirmationDialogViewController: BaseModalViewController<ConfirmationDialogStore> {
+final class ConfirmationDialogViewController: BaseStoredModalViewController<ConfirmationDialogStore> {
     private enum Metric {
         static let horizontalPadding: CGFloat = 40
         static let spacing: CGFloat = 8

--- a/Projects/Feature/HomeFeature/Sources/Scene/HomeViewController.swift
+++ b/Projects/Feature/HomeFeature/Sources/Scene/HomeViewController.swift
@@ -7,7 +7,7 @@ import Localization
 import MSGLayout
 import UIKit
 
-final class HomeViewController: BaseViewController<HomeStore> {
+final class HomeViewController: BaseStoredViewController<HomeStore> {
     private enum Metric {
         static let horizontalPadding: CGFloat = 20
         static let spacing: CGFloat = 12

--- a/Projects/Feature/NoticeFeature/Sources/Scene/NoticeViewController.swift
+++ b/Projects/Feature/NoticeFeature/Sources/Scene/NoticeViewController.swift
@@ -9,7 +9,7 @@ import NoticeDomainInterface
 import UIKit
 import UIKitUtil
 
-final class NoticeViewController: BaseViewController<NoticeStore> {
+final class NoticeViewController: BaseStoredViewController<NoticeStore> {
     private enum Metric {
         static let horizontalPadding: CGFloat = 20
         static let spacing: CGFloat = 12

--- a/Projects/Feature/SigninFeature/Sources/Scene/SigninViewController.swift
+++ b/Projects/Feature/SigninFeature/Sources/Scene/SigninViewController.swift
@@ -8,7 +8,7 @@ import MSGLayout
 import UIKit
 import UtilityModule
 
-final class SigninViewController: BaseViewController<SigninStore> {
+final class SigninViewController: BaseStoredViewController<SigninStore> {
     private let dotoriLogoImageView = UIImageView()
         .set(\.image, .Dotori.dotoriSigninLogo
             .withRenderingMode(.alwaysTemplate)

--- a/Projects/Feature/SplashFeature/Sources/Scene/SplashViewController.swift
+++ b/Projects/Feature/SplashFeature/Sources/Scene/SplashViewController.swift
@@ -3,7 +3,7 @@ import DesignSystem
 import MSGLayout
 import UIKit
 
-final class SplashViewController: BaseViewController<SplashStore> {
+final class SplashViewController: BaseStoredViewController<SplashStore> {
     private let dotoriLogoImageView = DotoriIconView(
         size: .custom(.init(width: 108, height: 108)),
         image: .Dotori.dotori


### PR DESCRIPTION
## 💡 개요
기존의 BaseViewController에서 한 번 더 추상화해서 BaseStoredViewController를 만듭니다

## 📃 작업내용
- BaseViewController를 BaseStoredViewController로 추상화하여 Store가 없는 버전의 혹은 Store가 여러개인 버전의 viewController 작성을 할 수 있도록 작업

## 🔀 변경사항
- 기존 BaseViewController를 상속하는 ViewController들을 BaseStoredViewController를 상속하도록 변경
- 기존 BaseModalViewController를 상속하는 ViewController들을 BaseStoredModalViewController를 상속하도록 변경