### PR TITLE
🔀 :: 자습 Cell에서 다크모드일때 성별 아이콘 색이 잘 안보이는 현상 해결

### DIFF
--- a/Projects/Feature/SelfStudyFeature/Sources/Scene/View/SelfStudyCell.swift
+++ b/Projects/Feature/SelfStudyFeature/Sources/Scene/View/SelfStudyCell.swift
@@ -108,7 +108,8 @@ final class SelfStudyCell: BaseTableViewCell<SelfStudyRankModel> {
         super.adapt(model: model)
         self.rankLabel.text = "\(model.rank)"
         self.nameLabel.text = model.memberName
-        self.genderImageView.image = model.gender == .man ? .Dotori.men : .Dotori.women
+        self.genderImageView.image = (model.gender == .man ? UIImage.Dotori.men : .Dotori.women)
+            .tintColor(color: .dotori(.neutral(.n10)))
         self.stuNumLabel.text = model.stuNum
         self.selfStudyCheckBox.isChecked = model.selfStudyCheck
         self.medalImageView.image = self.rankToImage(rank: model.rank)


### PR DESCRIPTION
## 💡 개요
다크모드일때 자습 Cell의 성별 아이콘이 어두워서 잘 안보였습니다.
성별 아이콘 Cell의 tintColor를 n10으로 두어 해결하였습니다.
<img src="https://github.com/Team-Ampersand/Dotori-iOS/assets/74440939/23a52893-7807-4d37-a7af-95777885c4b5" width="150" />

## 🔀 변경사항
성별 아이콘의 rendering모드를 original로 두고, tintColor를 n10으로 설정
