### PR TITLE
TabBar Image 위치 조정

### DIFF
--- a/Projects/Feature/MainTabFeature/Sources/Moordinator/MainTabMoordinator.swift
+++ b/Projects/Feature/MainTabFeature/Sources/Moordinator/MainTabMoordinator.swift
@@ -97,13 +97,11 @@ private extension MainTabMoordinator {
             root3.tabBarItem = selfStudyTabbarItem
             root4.tabBarItem = massageTabbarItem
             root5.tabBarItem = musicTabbarItem
-            
-            homeTabbarItem.imageInsets = UIEdgeInsets(top: 5, left: 0, bottom: -5, right: 0)
-            noticeTabbarItem.imageInsets = UIEdgeInsets(top: 5, left: 0, bottom: -5, right: 0)
-            selfStudyTabbarItem.imageInsets = UIEdgeInsets(top: 5, left: 0, bottom: -5, right: 0)
-            massageTabbarItem.imageInsets = UIEdgeInsets(top: 5, left: 0, bottom: -5, right: 0)
-            musicTabbarItem.imageInsets = UIEdgeInsets(top: 5, left: 0, bottom: -5, right: 0)
 
+            [homeTabbarItem, noticeTabbarItem, selfStudyTabbarItem, massageTabbarItem, musicTabbarItem].forEach {
+                $0.imageInsets = UIEdgeInsets(top: 5, left: 0, bottom: -5, right: 0)
+            }
+        
             self.rootVC.setViewControllers([root1, root2, root3, root4, root5], animated: true)
         }
         return .multiple([

--- a/Projects/Feature/MainTabFeature/Sources/Moordinator/MainTabMoordinator.swift
+++ b/Projects/Feature/MainTabFeature/Sources/Moordinator/MainTabMoordinator.swift
@@ -97,6 +97,12 @@ private extension MainTabMoordinator {
             root3.tabBarItem = selfStudyTabbarItem
             root4.tabBarItem = massageTabbarItem
             root5.tabBarItem = musicTabbarItem
+            
+            homeTabbarItem.imageInsets = UIEdgeInsets(top: 5, left: 0, bottom: -5, right: 0)
+            noticeTabbarItem.imageInsets = UIEdgeInsets(top: 5, left: 0, bottom: -5, right: 0)
+            selfStudyTabbarItem.imageInsets = UIEdgeInsets(top: 5, left: 0, bottom: -5, right: 0)
+            massageTabbarItem.imageInsets = UIEdgeInsets(top: 5, left: 0, bottom: -5, right: 0)
+            musicTabbarItem.imageInsets = UIEdgeInsets(top: 5, left: 0, bottom: -5, right: 0)
 
             self.rootVC.setViewControllers([root1, root2, root3, root4, root5], animated: true)
         }


### PR DESCRIPTION
## 💡 개요
TabBar Image를 조정해주었습니다.

<img width="377" alt="image" src="https://github.com/Team-Ampersand/Dotori-iOS/assets/105629604/9070197c-ef79-49b0-96c8-1cb5511ed771">
<img width="378" alt="image" src="https://github.com/Team-Ampersand/Dotori-iOS/assets/105629604/07962701-0ef1-4f41-bdfa-3290a99925ce">

위로 조금 올라가 있던 TabBarImage들을 가운데로 조정해주었습니다