### PR TITLE
🔀 :: [#142] ModalViewController의 dismiss가 subviews를 눌러도 적용되는 현상

### DIFF
--- a/Projects/Feature/FilterSelfStudyFeature/Sources/Scene/FilterSelfStudyViewController.swift
+++ b/Projects/Feature/FilterSelfStudyFeature/Sources/Scene/FilterSelfStudyViewController.swift
@@ -50,10 +50,10 @@ final class FilterSelfStudyViewController: BaseStoredModalViewController<FilterS
     }
 
     override func setLayout() {
-        MSGLayout.stackedLayout(self.view, ignoreSafeArea: true) {
-            SpacerView()
-
-            contentView
+        MSGLayout.buildLayout {
+            contentView.layout
+                .horizontal(.toSuperview())
+                .bottom(.toSuperview())
         }
 
         MSGLayout.stackedLayout(self.contentView) {

--- a/Projects/Shared/CombineUtility/Sources/UIGestureRecognizer/UIGestureRecognizer+publisher.swift
+++ b/Projects/Shared/CombineUtility/Sources/UIGestureRecognizer/UIGestureRecognizer+publisher.swift
@@ -27,7 +27,10 @@ extension UIGestureRecognizer {
         }
     }
 
-    final class Subscription<G: UIGestureRecognizer, S: Subscriber>: Combine.Subscription
+    final class Subscription<G: UIGestureRecognizer, S: Subscriber>:
+        NSObject,
+        Combine.Subscription,
+        UIGestureRecognizerDelegate
         where S.Input == G, S.Failure == Never {
 
         var subscriber: S?
@@ -38,7 +41,9 @@ extension UIGestureRecognizer {
             self.subscriber = subscriber
             self.gestureRecognizer = gestureRecognizer
             self.view = view
+            super.init()
             gestureRecognizer.addTarget(self, action: #selector(handle))
+            gestureRecognizer.delegate = self
             view.addGestureRecognizer(gestureRecognizer)
         }
 
@@ -51,5 +56,12 @@ extension UIGestureRecognizer {
         }
 
         func request(_ demand: Subscribers.Demand) { }
+
+        func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
+            guard touch.view == self.view else {
+                return false
+            }
+            return true
+        }
     }
 }


### PR DESCRIPTION
## 💡 개요
ModalViewController에서 빈화면을 누를때만이 아니라 실제 content가 들어가있는 contentView를 누를때 똑같이 dismiss route를 보내는 현상이 있었음

## 📃 작업내용
tapGesturePublisher에서 해당 gesture의 view인지 검사

## 🔀 변경사항
gesture의 touch인식 view를 해당 gesture를 추가한 view인지 검사
