### PR TITLE
🔀 :: [#145] 회원가입, 비밀번호 찾기에서 로그인 URL에 접근 시 로그인 화면으로 전환

### DIFF
--- a/Projects/Feature/RenewalPasswordFeature/Sources/Factory/RenewalPasswordFactory.swift
+++ b/Projects/Feature/RenewalPasswordFeature/Sources/Factory/RenewalPasswordFactory.swift
@@ -3,5 +3,5 @@ import Moordinator
 import UIKit
 
 public protocol RenewalPasswordFactory {
-    func makeViewController() -> UIViewController
+    func makeViewController(signinHandler: @escaping () -> Void) -> UIViewController
 }

--- a/Projects/Feature/RenewalPasswordFeature/Sources/Factory/RenewalPasswordFactoryImpl.swift
+++ b/Projects/Feature/RenewalPasswordFeature/Sources/Factory/RenewalPasswordFactoryImpl.swift
@@ -4,11 +4,12 @@ import Moordinator
 import UIKit
 
 struct RenewalPasswordFactoryImpl: RenewalPasswordFactory {
-    func makeViewController() -> UIViewController {
+    func makeViewController(signinHandler: @escaping () -> Void) -> UIViewController {
         let url = "https://www.dotori-gsm.com/changePasswd"
 
         return DWebViewController(
-            urlString: url
+            urlString: url,
+            detectHandler: signinHandler
         )
     }
 }

--- a/Projects/Feature/SigninFeature/Sources/Moordinator/SigninMoordinator.swift
+++ b/Projects/Feature/SigninFeature/Sources/Moordinator/SigninMoordinator.swift
@@ -38,12 +38,18 @@ final class SigninMoordinator: Moordinator {
             )
 
         case .signup:
-            let viewController = signupFactory.makeViewController()
+            let viewController = signupFactory.makeViewController { [rootVC] in
+                print("ASD")
+                rootVC.popViewController(animated: true)
+            }
             rootVC.pushViewController(viewController, animated: true)
             return .one(.contribute(withNextPresentable: viewController))
 
         case .renewalPassword:
-            let viewController = renewalPasswordFactory.makeViewController()
+            let viewController = renewalPasswordFactory.makeViewController { [rootVC] in
+                print("ASD")
+                rootVC.popViewController(animated: true)
+            }
             rootVC.pushViewController(viewController, animated: true)
             return .one(.contribute(withNextPresentable: viewController))
 

--- a/Projects/Feature/SignupFeature/Sources/Factory/SignupFactory.swift
+++ b/Projects/Feature/SignupFeature/Sources/Factory/SignupFactory.swift
@@ -3,5 +3,5 @@ import UIKit
 import Moordinator
 
 public protocol SignupFactory {
-    func makeViewController() -> UIViewController
+    func makeViewController(signinHandler: @escaping () -> Void) -> UIViewController
 }

--- a/Projects/Feature/SignupFeature/Sources/Factory/SignupFactoryImpl.swift
+++ b/Projects/Feature/SignupFeature/Sources/Factory/SignupFactoryImpl.swift
@@ -5,11 +5,12 @@ import DWebKit
 import UIKit
 
 struct SignupFactoryImpl: SignupFactory {
-    func makeViewController() -> UIViewController {
+    func makeViewController(signinHandler: @escaping () -> Void) -> UIViewController {
         let url = "https://www.dotori-gsm.com/signup"
 
         return DWebViewController(
-            urlString: url
+            urlString: url,
+            detectHandler: signinHandler
         )
     }
 }


### PR DESCRIPTION
## 💡 개요
현재 웹뷰인 회원가입, 비밀번호 찾기 화면에서 로그인 URL에 접근하면 로그인화면으로 사용자를 이동시킵니다

## 📃 작업내용
- DWebViewController에 URL 변경 감지 및 사용하는 코드에서 핸들링할 수 있도록 제작
- 회원가입, 비밀번호찾기 웹뷰에서 로그인 URL감지 시 pop

## 🔀 변경사항
- DWebViewController에 URL 변경 감지 추가

