### PR TITLE
🔀 :: [#174] 의존성이 없음에도 import를 하는 코드 제거

### DIFF
--- a/Projects/Feature/FilterSelfStudyFeature/Sources/Scene/FilterSelfStudyViewController.swift
+++ b/Projects/Feature/FilterSelfStudyFeature/Sources/Scene/FilterSelfStudyViewController.swift
@@ -1,5 +1,4 @@
 import Anim
-import BaseDomainInterface
 import BaseFeature
 import CombineUtility
 import Configure


### PR DESCRIPTION
## 💡 개요
FilterSelfStudyViewController에서 BaseDomainInterface를 의존하지도 않은 상태로 import해서 죽입니다.