### PR TITLE
🔀 :: [#181] ShareExtension 버그 해결

### DIFF
--- a/Projects/App/ShareExtension/Sources/DotoriShareViewController.swift
+++ b/Projects/App/ShareExtension/Sources/DotoriShareViewController.swift
@@ -181,7 +181,7 @@ private extension DotoriShareViewController {
                 return
             }
             self.bindInputURL(url: url)
-            
+
         default:
             self.cancelRequest("Invalid URL Input", code: 3)
         }

--- a/Projects/App/ShareExtension/Support/Info.plist
+++ b/Projects/App/ShareExtension/Support/Info.plist
@@ -28,6 +28,8 @@
 		<dict>
 			<key>NSExtensionActivationRule</key>
 			<dict>
+				<key>NSExtensionActivationSupportsText</key>
+				<true/>
 				<key>NSExtensionActivationDictionaryVersion</key>
 				<integer>1</integer>
 				<key>NSExtensionActivationSupportsWebURLWithMaxCount</key>


### PR DESCRIPTION
## 💡 개요
<img src="https://github.com/Team-Ampersand/Dotori-iOS/assets/74440939/532db9f7-1d94-40f6-9cac-7ee63d9a6251" width="150" />

유튜브 share inputItem이 plain-text인데 현재는 url만 받아요, 그래서 plain-text도 됩니다 이제!

## 📃 작업내용
- 공유 대상에 plain-text 지원
- ShareExtension 코드 메서드 분리 위주 리팩토링

## 🔀 변경사항
- 공유 대상에 plain-text 지원
