### PR TITLE
🔀 :: [#180] 자습신청 성공 문구 정상화

### DIFF
--- a/Projects/Feature/HomeFeature/Sources/Scene/Store/HomeStore.swift
+++ b/Projects/Feature/HomeFeature/Sources/Scene/Store/HomeStore.swift
@@ -221,7 +221,7 @@ private extension HomeStore {
                 self.route.send(confirmRoutePath)
             } else {
                 try await self.applySelfStudyUseCase()
-                await DotoriToast.makeToast(text: L10n.Home.completeToApplyMassageTitle, style: .success)
+                await DotoriToast.makeToast(text: L10n.Home.completeToApplySelfStudyTitle, style: .success)
             }
             self.send(.refreshSelfStudyButtonDidTap)
         } catch: { @MainActor error in


### PR DESCRIPTION
## 💡 개요
자습신청에 성공했을 때 토스트 메시지가 안마의자 신청에 성공했다고 뜨는 것을 수정
