### PR TITLE
🔀 :: [#185] 공지 상세 페이지 뒤로가기 버튼 디자인 반영

### DIFF
--- a/Projects/Feature/NoticeFeature/Sources/Scene/NoticeViewController.swift
+++ b/Projects/Feature/NoticeFeature/Sources/Scene/NoticeViewController.swift
@@ -80,6 +80,7 @@ final class NoticeViewController: BaseStoredViewController<NoticeStore> {
 
     override func configureNavigation() {
         self.navigationItem.setLeftBarButton(dotoriBarButton, animated: true)
+        self.navigationItem.configDotoriBackButton()
         self.view.backgroundColor = .dotori(.background(.card))
     }
 

--- a/Projects/UserInterface/DesignSystem/Sources/Extension/UINavigationItem+dotoriBackButton.swift
+++ b/Projects/UserInterface/DesignSystem/Sources/Extension/UINavigationItem+dotoriBackButton.swift
@@ -1,0 +1,9 @@
+import UIKit
+
+public extension UINavigationItem {
+    func configDotoriBackButton(title: String = "") {
+        let backButton = UIBarButtonItem(title: title, style: .plain, target: nil, action: nil)
+        backButton.tintColor = .dotori(.neutral(.n20))
+        self.backBarButtonItem = backButton
+    }
+}


### PR DESCRIPTION
## 💡 개요
공지 상세 페이지의 뒤로가기 버튼을 디자인과 일치시키기

## 📃 작업내용
- 도토리 스타일의 뒤로가기 버튼 extension화
- 공지 상세 페이지의 뒤로가기 버튼이 기본 뒤로가기 버튼이였던 것을 실제 디자인과 맞게 만들어줍니다

## 🔀 변경사항
<div>
  <img src="https://github.com/Team-Ampersand/Dotori-iOS/assets/74440939/6ce96f2b-a282-492e-aaab-04905e49de1a" width="150" />
  <img src="https://github.com/Team-Ampersand/Dotori-iOS/assets/74440939/8a4da374-fc10-4176-ae68-b7f770ed7452" width="150" />
</div>


## 🍴 사용방법
```swift
self.navigationitem.configDotoriBackButton()
self.navigationitem.configDotoriBackButton(title: "Asdf")
```
