### PR TITLE
🔀 :: [#201] 데이터 fetching 시점 변경

### DIFF
--- a/Projects/Feature/MassageFeature/Sources/Scene/MassageStore.swift
+++ b/Projects/Feature/MassageFeature/Sources/Scene/MassageStore.swift
@@ -27,7 +27,7 @@ final class MassageStore: BaseStore {
     }
 
     enum Action {
-        case viewDidLoad
+        case viewWillAppear
         case fetchMassageRankList
     }
 
@@ -40,8 +40,8 @@ final class MassageStore: BaseStore {
 extension MassageStore {
     func mutate(state: State, action: Action) -> SideEffect<Mutation, Never> {
         switch action {
-        case .viewDidLoad:
-            return viewDidLoad()
+        case .viewWillAppear:
+            return viewWillAppear()
 
         case .fetchMassageRankList:
             return fetchMassageRankList()
@@ -66,7 +66,7 @@ extension MassageStore {
 
 // MARK: - Mutate
 private extension MassageStore {
-    func viewDidLoad() -> SideEffect<Mutation, Never> {
+    func viewWillAppear() -> SideEffect<Mutation, Never> {
         return self.fetchMassageRankList()
     }
 

--- a/Projects/Feature/MassageFeature/Sources/Scene/MassageViewController.swift
+++ b/Projects/Feature/MassageFeature/Sources/Scene/MassageViewController.swift
@@ -11,7 +11,6 @@ final class MassageViewController: BaseStoredViewController<MassageStore> {
     private let massageNavigationBarLabel = DotoriNavigationBarLabel(text: L10n.Massage.massageTitle)
     private let massageTableView = UITableView()
         .set(\.backgroundColor, .clear)
-        .set(\.isHidden, true)
         .set(\.separatorStyle, .none)
         .set(\.sectionHeaderHeight, 0)
         .then {
@@ -96,11 +95,9 @@ final class MassageViewController: BaseStoredViewController<MassageStore> {
         sharedState
             .map(\.massageRankList)
             .map(\.isEmpty)
+            .not()
             .removeDuplicates()
-            .sink(with: self, receiveValue: { owner, massageIsEmpty in
-                owner.massageTableView.isHidden = massageIsEmpty
-                owner.emptySelfStudyStackView.isHidden = !massageIsEmpty
-            })
+            .assign(to: \.isHidden, on: emptySelfStudyStackView)
             .store(in: &subscription)
     }
 }

--- a/Projects/Feature/MassageFeature/Sources/Scene/MassageViewController.swift
+++ b/Projects/Feature/MassageFeature/Sources/Scene/MassageViewController.swift
@@ -63,8 +63,8 @@ final class MassageViewController: BaseStoredViewController<MassageStore> {
     }
 
     override func bindAction() {
-        viewDidLoadPublisher
-            .map { Store.Action.viewDidLoad }
+        viewWillAppearPublisher
+            .map { Store.Action.viewWillAppear }
             .sink(receiveValue: store.send(_:))
             .store(in: &subscription)
 

--- a/Projects/Feature/SelfStudyFeature/Sources/Scene/SelfStudyViewController.swift
+++ b/Projects/Feature/SelfStudyFeature/Sources/Scene/SelfStudyViewController.swift
@@ -77,7 +77,7 @@ final class SelfStudyViewController: BaseStoredViewController<SelfStudyStore> {
     }
 
     override func bindAction() {
-        viewDidLoadPublisher
+        viewWillAppearPublisher
             .merge(with: selfStudyRefreshContorol.controlPublisher(for: .valueChanged).map { _ in })
             .map { Store.Action.fetchSelfStudyRank }
             .sink(receiveValue: store.send(_:))

--- a/Projects/Feature/SelfStudyFeature/Sources/Scene/SelfStudyViewController.swift
+++ b/Projects/Feature/SelfStudyFeature/Sources/Scene/SelfStudyViewController.swift
@@ -23,7 +23,6 @@ final class SelfStudyViewController: BaseStoredViewController<SelfStudyStore> {
         .set(\.separatorStyle, .none)
         .set(\.sectionHeaderHeight, 0)
         .set(\.sectionFooterHeight, 0)
-        .set(\.isHidden, true)
         .then {
             $0.register(cellType: SelfStudyCell.self)
         }

--- a/Projects/Feature/SelfStudyFeature/Sources/Scene/SelfStudyViewController.swift
+++ b/Projects/Feature/SelfStudyFeature/Sources/Scene/SelfStudyViewController.swift
@@ -103,11 +103,9 @@ final class SelfStudyViewController: BaseStoredViewController<SelfStudyStore> {
         sharedState
             .map(\.selfStudyRankList)
             .map(\.isEmpty)
+            .not()
             .removeDuplicates()
-            .sink(with: self, receiveValue: { owner, selfStudyIsEmpty in
-                owner.selfStudyTableView.isHidden = selfStudyIsEmpty
-                owner.emptySelfStudyStackView.isHidden = !selfStudyIsEmpty
-            })
+            .assign(to: \.isHidden, on: emptySelfStudyStackView)
             .store(in: &subscription)
 
         sharedState

--- a/Projects/Shared/CombineUtility/Sources/Publisher/Publisher+not.swift
+++ b/Projects/Shared/CombineUtility/Sources/Publisher/Publisher+not.swift
@@ -1,0 +1,7 @@
+import Combine
+
+public extension Publisher where Output == Bool {
+    func not() -> Publishers.Map<Self, Bool> {
+        self.map { !$0 }
+    }
+}


### PR DESCRIPTION
## 💡 개요
기존에 자습, 안마의자 ViewController에서 자습, 안마 신청리스트를 가져올 때 viewDidLoad에서 가져옴
-> 이로인한 문제로, 첫번째로 데이터를 가져오는 시점에 데이터가 빈 상태로오고 이후에는 백엔드상에 데이터가 있어도 다시 가져오지 않는 문제 발생

## 📃 작업내용
- 자습, 안마의자 화면에서 Refresh 허용

## 🔀 변경사항
- 자습, 안마의자 화면에서 데이터 가져오는 시점 변경 viewDidLoad -> viewWillAppear
