### PR TITLE
🔀 :: [#210] 로그인 버튼 GAuth 버튼으로 리펙토링

### DIFF
--- a/Plugin/DependencyPlugin/ProjectDescriptionHelpers/Dependency+SPM.swift
+++ b/Plugin/DependencyPlugin/ProjectDescriptionHelpers/Dependency+SPM.swift
@@ -5,6 +5,7 @@ public extension TargetDependency {
 }
 
 public extension TargetDependency.SPM {
+    static let GAuthSignin = TargetDependency.external(name: "GAuthSignin")
     static let Lottie = TargetDependency.external(name: "Lottie")
     static let Nuke = TargetDependency.external(name: "Nuke")
     static let Anim = TargetDependency.external(name: "Anim")

--- a/Projects/Domain/AuthDomain/Project.swift
+++ b/Projects/Domain/AuthDomain/Project.swift
@@ -6,11 +6,13 @@ let project = Project.module(
     name: ModulePaths.Domain.AuthDomain.rawValue,
     targets: [
         .interface(module: .domain(.AuthDomain), dependencies: [
-            .domain(target: .BaseDomain, type: .interface)
+            .domain(target: .BaseDomain, type: .interface),
+            .SPM.GAuthSignin
         ]),
         .implements(module: .domain(.AuthDomain), dependencies: [
             .domain(target: .AuthDomain, type: .interface),
-            .domain(target: .BaseDomain)
+            .domain(target: .BaseDomain),
+            .SPM.GAuthSignin
         ]),
         .testing(module: .domain(.AuthDomain), dependencies: [
             .domain(target: .AuthDomain, type: .interface)

--- a/Projects/Feature/SigninFeature/Project.swift
+++ b/Projects/Feature/SigninFeature/Project.swift
@@ -6,14 +6,16 @@ let project = Project.module(
     name: ModulePaths.Feature.SigninFeature.rawValue,
     targets: [
         .interface(module: .feature(.SigninFeature), dependencies: [
-            .feature(target: .BaseFeature, type: .interface)
+            .feature(target: .BaseFeature, type: .interface),
+            .SPM.GAuthSignin
         ]),
         .implements(module: .feature(.SigninFeature), dependencies: [
             .feature(target: .BaseFeature),
             .feature(target: .SigninFeature, type: .interface),
             .feature(target: .SignupFeature, type: .interface),
             .feature(target: .RenewalPasswordFeature, type: .interface),
-            .domain(target: .AuthDomain, type: .interface)
+            .domain(target: .AuthDomain, type: .interface),
+            .SPM.GAuthSignin
         ]),
         .tests(module: .feature(.SigninFeature), dependencies: [
             .feature(target: .SigninFeature)

--- a/Projects/Feature/SigninFeature/Sources/Scene/SigninViewController.swift
+++ b/Projects/Feature/SigninFeature/Sources/Scene/SigninViewController.swift
@@ -7,6 +7,7 @@ import Localization
 import MSGLayout
 import UIKit
 import UtilityModule
+import GAuthSignin
 
 final class SigninViewController: BaseStoredViewController<SigninStore> {
     private let dotoriLogoImageView = UIImageView()
@@ -17,11 +18,6 @@ final class SigninViewController: BaseStoredViewController<SigninStore> {
                 .withTintColor(.dotori(.primary(.p10)))
                 .resize(width: 182, height: 41)
         )
-    private let dotoriSubTitle = DotoriLabel(
-        "광주소프트웨어마이스터고\n기숙사 관리 시스템, DOTORI",
-        textColor: .neutral(.n20),
-        font: .subtitle2
-    )
     private let signinButton = GAuthButton(
         auth: .signin,
         color: .colored,
@@ -31,11 +27,7 @@ final class SigninViewController: BaseStoredViewController<SigninStore> {
     override func addView() {
         view.addSubviews {
             dotoriLogoImageView
-            emailTextField
-            passwordTextField
-            renewalPasswordButton
             signinButton
-            signupButton
         }
     }
 
@@ -46,28 +38,11 @@ final class SigninViewController: BaseStoredViewController<SigninStore> {
                 .top(.to(view.safeAreaLayoutGuide).top, .equal(20))
                 .height(41)
 
-            emailTextField.layout
-                .centerX(.toSuperview())
-                .horizontal(.toSuperview(), .equal(20))
-                .top(.to(dotoriLogoImageView).bottom, .equal(30))
-
-            passwordTextField.layout
-                .centerX(.toSuperview())
-                .horizontal(.toSuperview(), .equal(20))
-                .top(.to(emailTextField).bottom, .equal(8))
-
-            renewalPasswordButton.layout
-                .trailing(.to(passwordTextField).trailing)
-                .top(.to(passwordTextField).bottom, .equal(8))
-
             signinButton.layout
                 .centerX(.toSuperview())
                 .horizontal(.toSuperview(), .equal(20))
-                .top(.to(renewalPasswordButton).bottom, .equal(32))
-
-            signupButton.layout
-                .centerX(.toSuperview())
-                .top(.to(signinButton).bottom, .equal(16))
+                .bottom(.toSuperview(), .equal(-60))
+                .height(50)
         }
     }
 
@@ -80,26 +55,6 @@ final class SigninViewController: BaseStoredViewController<SigninStore> {
     }
 
     override func bindAction() {
-        emailTextField.textPublisher
-            .map(Store.Action.updateEmail)
-            .sink(receiveValue: store.send(_:))
-            .store(in: &subscription)
-
-        passwordTextField.textPublisher
-            .map(Store.Action.updatePassword)
-            .sink(receiveValue: store.send(_:))
-            .store(in: &subscription)
-
-        signupButton.tapPublisher
-            .map { Store.Action.signupButtonDidTap }
-            .sink(receiveValue: store.send(_:))
-            .store(in: &subscription)
-
-        renewalPasswordButton.tapPublisher
-            .map { Store.Action.renewalPasswordButtonDidTap }
-            .sink(receiveValue: store.send(_:))
-            .store(in: &subscription)
-
         signinButton.tapPublisher
             .map { Store.Action.signinButtonDidTap }
             .sink(receiveValue: store.send(_:))

--- a/Projects/Feature/SigninFeature/Sources/Scene/SigninViewController.swift
+++ b/Projects/Feature/SigninFeature/Sources/Scene/SigninViewController.swift
@@ -13,47 +13,57 @@ final class SigninViewController: BaseStoredViewController<SigninStore> {
     private let dotoriLogoImageView = UIImageView()
         .set(
             \.image,
-            .Dotori.dotoriSigninLogo
+             .Dotori.dotoriSigninLogo
                 .withRenderingMode(.alwaysTemplate)
                 .withTintColor(.dotori(.primary(.p10)))
                 .resize(width: 182, height: 41)
         )
+    private let dotoriSubTitle = DotoriLabel(
+        "광주소프트웨어마이스터고\n기숙사 관리 시스템, DOTORI",
+        textColor: .neutral(.n20), font: .subtitle2)
+        .set(\.numberOfLines, 0)
+        .set(\.textAlignment, .center)
     private let signinButton = GAuthButton(
         auth: .signin,
         color: .colored,
         rounded: .default
     )
-
+    
     override func addView() {
         view.addSubviews {
             dotoriLogoImageView
+            dotoriSubTitle
             signinButton
         }
     }
-
+    
     override func setLayout() {
         MSGLayout.buildLayout {
             dotoriLogoImageView.layout
                 .centerX(.toSuperview())
-                .top(.to(view.safeAreaLayoutGuide).top, .equal(20))
+                .top(.to(view.safeAreaLayoutGuide).top, .equal(233))
                 .height(41)
-
+            
+            dotoriSubTitle.layout
+                .centerX(.toSuperview())
+                .top(.to(dotoriLogoImageView).bottom, .equal(21))
+            
             signinButton.layout
                 .centerX(.toSuperview())
                 .horizontal(.toSuperview(), .equal(20))
-                .bottom(.toSuperview(), .equal(-60))
+                .bottom(.to(view.safeAreaLayoutGuide), .equal(-60))
                 .height(50)
         }
     }
-
+    
     override func configureViewController() {
         self.view.backgroundColor = .dotori(.background(.card))
     }
-
+    
     override func configureNavigation() {
         self.navigationItem.title = L10n.Signin.loginNavigationTitle
     }
-
+    
     override func bindAction() {
         signinButton.tapPublisher
             .map { Store.Action.signinButtonDidTap }
@@ -61,3 +71,4 @@ final class SigninViewController: BaseStoredViewController<SigninStore> {
             .store(in: &subscription)
     }
 }
+

--- a/Projects/Feature/SigninFeature/Sources/Scene/SigninViewController.swift
+++ b/Projects/Feature/SigninFeature/Sources/Scene/SigninViewController.swift
@@ -17,34 +17,16 @@ final class SigninViewController: BaseStoredViewController<SigninStore> {
                 .withTintColor(.dotori(.primary(.p10)))
                 .resize(width: 182, height: 41)
         )
-    private let emailTextField = DotoriIconTextField(
-        placeholder: L10n.Signin.emailPlaceholder,
-        icon: .Dotori.person
-    )
-    private let passwordTextField = DotoriIconTextField(
-        placeholder: L10n.Signin.passwordPlaceholder,
-        icon: .Dotori.lock
-    )
-    .set(\.isSecureTextEntry, true)
-    private let renewalPasswordButton = DotoriTextButton(
-        L10n.Signin.findPasswordButtonTitle,
+    private let dotoriSubTitle = DotoriLabel(
+        "광주소프트웨어마이스터고\n기숙사 관리 시스템, DOTORI",
         textColor: .neutral(.n20),
-        font: .body2
+        font: .subtitle2
     )
-    private let signinButton = DotoriButton(text: L10n.Signin.loginButtonTitle)
-        .set(\.contentEdgeInsets, .vertical(16))
-    private let signupButton = DotoriTextButton(
-        L10n.Signin.signupButtonTitle,
-        textColor: .neutral(.n20),
-        font: .body2
-    ).then {
-        let signupString = NSMutableAttributedString(string: $0.titleLabel?.text ?? "")
-        signupString.setColorForText(
-            textToFind: L10n.Signin.signupTitle,
-            withColor: .dotori(.primary(.p10))
-        )
-        $0.setAttributedTitle(signupString, for: .normal)
-    }
+    private let signinButton = GAuthButton(
+        auth: .signin,
+        color: .colored,
+        rounded: .default
+    )
 
     override func addView() {
         view.addSubviews {

--- a/Tuist/Dependencies.swift
+++ b/Tuist/Dependencies.swift
@@ -5,6 +5,7 @@ let dependencies = Dependencies(
     carthage: nil,
     swiftPackageManager: SwiftPackageManagerDependencies(
         [
+            .remote(url: "https://github.com/GSM-MSG/GAuthSignin-Swift", requirement: .exact("0.0.3")),
             .remote(url: "https://github.com/airbnb/lottie-ios.git", requirement: .exact("4.2.0")),
             .remote(url: "https://github.com/kean/Nuke.git", requirement: .exact("12.1.4")),
             .remote(url: "https://github.com/GSM-MSG/Anim.git", requirement: .exact("1.1.0")),
@@ -22,7 +23,8 @@ let dependencies = Dependencies(
         ],
         productTypes: [
             "Moordinator": .framework,
-            "CombineMiniature": .framework
+            "CombineMiniature": .framework,
+            "GAuthSignin": .framework
         ],
         baseSettings: .settings(
             configurations: [


### PR DESCRIPTION
## 💡 개요
로그인 버튼 GAuth 버튼으로 리펙토링

## 📃 작업내용
기존 로그인 버튼을 GAuth로그인 버튼으로 리펙토링 했습니다.

## 🔀 변경사항
emailTextField, passwordTextField, renewalPasswordButton, signupButton이 삭제 되었습니다.