### PR TITLE
🔀 :: [#237] 자습신청자 페이지, 안마의자 신청자 페이지에서 프로필 이미지 보여주기

### DIFF
--- a/Projects/Domain/MassageDomain/Interface/Entity/MassageRankEntity.swift
+++ b/Projects/Domain/MassageDomain/Interface/Entity/MassageRankEntity.swift
@@ -7,12 +7,16 @@ public struct MassageRankEntity: Equatable {
     public let stuNum: String
     public let memberName: String
     public let gender: GenderType
+    public let profileImage: String?
 
-    public init(id: Int, rank: Int, stuNum: String, memberName: String, gender: GenderType) {
+    public init(
+        id: Int, rank: Int, stuNum: String, memberName: String, gender: GenderType, profileImage: String
+    ) {
         self.id = id
         self.rank = rank
         self.stuNum = stuNum
         self.memberName = memberName
         self.gender = gender
+        self.profileImage = profileImage
     }
 }

--- a/Projects/Domain/MassageDomain/Interface/Entity/MassageRankEntity.swift
+++ b/Projects/Domain/MassageDomain/Interface/Entity/MassageRankEntity.swift
@@ -10,7 +10,7 @@ public struct MassageRankEntity: Equatable {
     public let profileImage: String?
 
     public init(
-        id: Int, rank: Int, stuNum: String, memberName: String, gender: GenderType, profileImage: String
+        id: Int, rank: Int, stuNum: String, memberName: String, gender: GenderType, profileImage: String?
     ) {
         self.id = id
         self.rank = rank

--- a/Projects/Domain/MassageDomain/Sources/DTO/Response/FetchMassageRankListResponseDTO.swift
+++ b/Projects/Domain/MassageDomain/Sources/DTO/Response/FetchMassageRankListResponseDTO.swift
@@ -30,7 +30,7 @@ extension FetchMassageRankListResponseDTO.MassageRankResponseDTO {
             stuNum: stuNum,
             memberName: memberName,
             gender: gender,
-            profileImage: profileImage ?? ""
+            profileImage: profileImage
         )
     }
 }

--- a/Projects/Domain/MassageDomain/Sources/DTO/Response/FetchMassageRankListResponseDTO.swift
+++ b/Projects/Domain/MassageDomain/Sources/DTO/Response/FetchMassageRankListResponseDTO.swift
@@ -11,6 +11,7 @@ struct FetchMassageRankListResponseDTO: Decodable {
         let stuNum: String
         let memberName: String
         let gender: GenderType
+        let profileImage: String?
     }
 }
 
@@ -23,6 +24,13 @@ extension FetchMassageRankListResponseDTO {
 
 extension FetchMassageRankListResponseDTO.MassageRankResponseDTO {
     func toDomain() -> MassageRankEntity {
-        MassageRankEntity(id: id, rank: rank, stuNum: stuNum, memberName: memberName, gender: gender)
+        MassageRankEntity(
+            id: id,
+            rank: rank,
+            stuNum: stuNum,
+            memberName: memberName,
+            gender: gender,
+            profileImage: profileImage ?? ""
+        )
     }
 }

--- a/Projects/Domain/MassageDomain/Tests/FetchMassageRankListUseCaseTests.swift
+++ b/Projects/Domain/MassageDomain/Tests/FetchMassageRankListUseCaseTests.swift
@@ -20,7 +20,14 @@ final class FetchMassageRankListUseCaseTests: XCTestCase {
     func testFetchMassageInfo() async throws {
         XCTAssertEqual(massageRepository.fetchMassageRankListCallCount, 0)
         let expected = [
-            MassageRankModel(id: 1, rank: 2, stuNum: "1111", memberName: "김시훈", gender: .man)
+            MassageRankModel(
+                id: 1,
+                rank: 2,
+                stuNum: "1111",
+                memberName: "김시훈",
+                gender: .man,
+                profileImage: ""
+            )
         ]
         massageRepository.fetchMassageRankListHandler = { expected }
 

--- a/Projects/Domain/MassageDomain/Tests/MassageRepositoryTests.swift
+++ b/Projects/Domain/MassageDomain/Tests/MassageRepositoryTests.swift
@@ -45,7 +45,14 @@ final class MassageRepositoryTests: XCTestCase {
     func testFetchMassageRankList() async throws {
         XCTAssertEqual(remoteMassageDataSource.fetchMassageRankListCallCount, 0)
         let expected = [
-            MassageRankModel(id: 1, rank: 2, stuNum: "3218", memberName: "전승원", gender: .man)
+            MassageRankModel(
+                id: 1,
+                rank: 2,
+                stuNum: "3218",
+                memberName: "전승원",
+                gender: .man,
+                profileImage: ""
+            )
         ]
         remoteMassageDataSource.fetchMassageRankListHandler = { expected }
 

--- a/Projects/Domain/SelfStudyDomain/Interface/Entity/SelfStudyRankEntity.swift
+++ b/Projects/Domain/SelfStudyDomain/Interface/Entity/SelfStudyRankEntity.swift
@@ -8,6 +8,7 @@ public struct SelfStudyRankEntity: Equatable {
     public let memberName: String
     public let gender: GenderType
     public let selfStudyCheck: Bool
+    public let profileImage: String?
 
     public init(
         id: Int,
@@ -15,7 +16,8 @@ public struct SelfStudyRankEntity: Equatable {
         stuNum: String,
         memberName: String,
         gender: GenderType,
-        selfStudyCheck: Bool
+        selfStudyCheck: Bool,
+        profileImage: String
     ) {
         self.id = id
         self.rank = rank
@@ -23,5 +25,6 @@ public struct SelfStudyRankEntity: Equatable {
         self.memberName = memberName
         self.gender = gender
         self.selfStudyCheck = selfStudyCheck
+        self.profileImage = profileImage
     }
 }

--- a/Projects/Domain/SelfStudyDomain/Interface/Entity/SelfStudyRankEntity.swift
+++ b/Projects/Domain/SelfStudyDomain/Interface/Entity/SelfStudyRankEntity.swift
@@ -17,7 +17,7 @@ public struct SelfStudyRankEntity: Equatable {
         memberName: String,
         gender: GenderType,
         selfStudyCheck: Bool,
-        profileImage: String
+        profileImage: String?
     ) {
         self.id = id
         self.rank = rank

--- a/Projects/Domain/SelfStudyDomain/Sources/DTO/Response/FecthSelfStudyRankListResponseDTO.swift
+++ b/Projects/Domain/SelfStudyDomain/Sources/DTO/Response/FecthSelfStudyRankListResponseDTO.swift
@@ -6,8 +6,8 @@ struct FetchSelfStudyRankListResponseDTO: Decodable {
     let list: [SelfStudyRankResponseDTO]
 
     struct SelfStudyRankResponseDTO: Decodable {
-        let rank: Int
         let id: Int
+        let rank: Int
         let stuNum: String
         let memberName: String
         let gender: GenderType

--- a/Projects/Domain/SelfStudyDomain/Sources/DTO/Response/FecthSelfStudyRankListResponseDTO.swift
+++ b/Projects/Domain/SelfStudyDomain/Sources/DTO/Response/FecthSelfStudyRankListResponseDTO.swift
@@ -6,12 +6,13 @@ struct FetchSelfStudyRankListResponseDTO: Decodable {
     let list: [SelfStudyRankResponseDTO]
 
     struct SelfStudyRankResponseDTO: Decodable {
-        let id: Int
         let rank: Int
+        let id: Int
         let stuNum: String
         let memberName: String
         let gender: GenderType
         let selfStudyCheck: Bool
+        let profileImage: String?
     }
 }
 
@@ -23,7 +24,8 @@ extension FetchSelfStudyRankListResponseDTO.SelfStudyRankResponseDTO {
             stuNum: stuNum,
             memberName: memberName,
             gender: gender,
-            selfStudyCheck: selfStudyCheck
+            selfStudyCheck: selfStudyCheck,
+            profileImage: profileImage ?? ""
         )
     }
 }

--- a/Projects/Domain/SelfStudyDomain/Sources/DTO/Response/FecthSelfStudyRankListResponseDTO.swift
+++ b/Projects/Domain/SelfStudyDomain/Sources/DTO/Response/FecthSelfStudyRankListResponseDTO.swift
@@ -25,7 +25,7 @@ extension FetchSelfStudyRankListResponseDTO.SelfStudyRankResponseDTO {
             memberName: memberName,
             gender: gender,
             selfStudyCheck: selfStudyCheck,
-            profileImage: profileImage ?? ""
+            profileImage: profileImage
         )
     }
 }

--- a/Projects/Domain/SelfStudyDomain/Tests/FetchSelfStudyRankListUseCaseTests.swift
+++ b/Projects/Domain/SelfStudyDomain/Tests/FetchSelfStudyRankListUseCaseTests.swift
@@ -19,7 +19,15 @@ final class FetchSelfStudyRankListUseCaseTests: XCTestCase {
 
     func testFetchSelfStudyRankList_When_ReqNil() async throws {
         let expected = [
-            SelfStudyRankModel(id: 1, rank: 1, stuNum: "3218", memberName: "김준", gender: .man, selfStudyCheck: true)
+            SelfStudyRankModel(
+                id: 1,
+                rank: 1,
+                stuNum: "3218",
+                memberName: "김준",
+                gender: .man,
+                selfStudyCheck: true,
+                profileImage: ""
+            )
         ]
         selfStudyRepository.fetchSelfStudyRankListReturn = expected
 
@@ -31,7 +39,15 @@ final class FetchSelfStudyRankListUseCaseTests: XCTestCase {
 
     func testFetchSelfStudyRankList() async throws {
         let expected = [
-            SelfStudyRankModel(id: 1, rank: 1, stuNum: "3218", memberName: "김준", gender: .man, selfStudyCheck: true)
+            SelfStudyRankModel(
+                id: 1,
+                rank: 1,
+                stuNum: "3218",
+                memberName: "김준",
+                gender: .man,
+                selfStudyCheck: true,
+                profileImage: ""
+            )
         ]
         selfStudyRepository.fetchSelfStudyRankSearchReturn = expected
 

--- a/Projects/Feature/HomeFeature/Demo/Sources/AppDelegate.swift
+++ b/Projects/Feature/HomeFeature/Demo/Sources/AppDelegate.swift
@@ -23,6 +23,7 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
                 .autoconnect()
                 .eraseToAnyPublisher()
         }
+        let fetchProfileImageUseCase: FetchProfileImageUseCaseSpy = .init()
         let fetchSelfStudyInfoUseCase: FetchSelfStudyInfoUseCaseSpy = .init()
         let fetchMassageInfoUseCase: FetchMassageInfoUseCaseSpy = .init()
         let fetchMealInfoUseCase: FetchMealInfoUseCaseSpy = .init()
@@ -38,6 +39,7 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
         let withdrawalUseCase = WithdrawalUseCaseSpy()
         let store = HomeStore(
             repeatableTimer: repeatableTimerStub,
+            fetchProfileImageUseCase: fetchProfileImageUseCase,
             fetchSelfStudyInfoUseCase: fetchSelfStudyInfoUseCase,
             fetchMassageInfoUseCase: fetchMassageInfoUseCase,
             fetchMealInfoUseCase: fetchMealInfoUseCase,

--- a/Projects/Feature/HomeFeature/Sources/Assembly/HomeAssembly.swift
+++ b/Projects/Feature/HomeFeature/Sources/Assembly/HomeAssembly.swift
@@ -17,7 +17,8 @@ public final class HomeAssembly: Assembly {
     public func assemble(container: Container) {
         container.register(HomeFactory.self) { resolver in
             HomeFactoryImpl(
-                repeatableTimer: resolver.resolve(RepeatableTimer.self)!,
+                repeatableTimer: resolver.resolve(RepeatableTimer.self)!, 
+                fetchProfileImageUseCase: resolver.resolve(FetchProfileImageUseCase.self)!,
                 fetchSelfStudyInfoUseCase: resolver.resolve(FetchSelfStudyInfoUseCase.self)!,
                 fetchMassageInfoUseCase: resolver.resolve(FetchMassageInfoUseCase.self)!,
                 fetchMealInfoUseCase: resolver.resolve(FetchMealInfoUseCase.self)!,

--- a/Projects/Feature/HomeFeature/Sources/Assembly/HomeAssembly.swift
+++ b/Projects/Feature/HomeFeature/Sources/Assembly/HomeAssembly.swift
@@ -17,7 +17,7 @@ public final class HomeAssembly: Assembly {
     public func assemble(container: Container) {
         container.register(HomeFactory.self) { resolver in
             HomeFactoryImpl(
-                repeatableTimer: resolver.resolve(RepeatableTimer.self)!, 
+                repeatableTimer: resolver.resolve(RepeatableTimer.self)!,
                 fetchProfileImageUseCase: resolver.resolve(FetchProfileImageUseCase.self)!,
                 fetchSelfStudyInfoUseCase: resolver.resolve(FetchSelfStudyInfoUseCase.self)!,
                 fetchMassageInfoUseCase: resolver.resolve(FetchMassageInfoUseCase.self)!,

--- a/Projects/Feature/HomeFeature/Sources/Factory/HomeFactoryImpl.swift
+++ b/Projects/Feature/HomeFeature/Sources/Factory/HomeFactoryImpl.swift
@@ -13,6 +13,7 @@ import UserDomainInterface
 
 struct HomeFactoryImpl: HomeFactory {
     private let repeatableTimer: any RepeatableTimer
+    private let fetchProfileImageUseCase: any FetchProfileImageUseCase
     private let fetchSelfStudyInfoUseCase: any FetchSelfStudyInfoUseCase
     private let fetchMassageInfoUseCase: any FetchMassageInfoUseCase
     private let fetchMealInfoUseCase: any FetchMealInfoUseCase
@@ -33,6 +34,7 @@ struct HomeFactoryImpl: HomeFactory {
 
     init(
         repeatableTimer: any RepeatableTimer,
+        fetchProfileImageUseCase: any FetchProfileImageUseCase,
         fetchSelfStudyInfoUseCase: any FetchSelfStudyInfoUseCase,
         fetchMassageInfoUseCase: any FetchMassageInfoUseCase,
         fetchMealInfoUseCase: any FetchMealInfoUseCase,
@@ -52,6 +54,7 @@ struct HomeFactoryImpl: HomeFactory {
         imagePickerFactory: any ImagePickerFactory
     ) {
         self.repeatableTimer = repeatableTimer
+        self.fetchProfileImageUseCase = fetchProfileImageUseCase
         self.fetchSelfStudyInfoUseCase = fetchSelfStudyInfoUseCase
         self.fetchMassageInfoUseCase = fetchMassageInfoUseCase
         self.fetchMealInfoUseCase = fetchMealInfoUseCase
@@ -74,6 +77,7 @@ struct HomeFactoryImpl: HomeFactory {
     func makeMoordinator() -> Moordinator {
         let homeStore = HomeStore(
             repeatableTimer: repeatableTimer,
+            fetchProfileImageUseCase: fetchProfileImageUseCase,
             fetchSelfStudyInfoUseCase: fetchSelfStudyInfoUseCase,
             fetchMassageInfoUseCase: fetchMassageInfoUseCase,
             fetchMealInfoUseCase: fetchMealInfoUseCase,

--- a/Projects/Feature/HomeFeature/Sources/Scene/Store/HomeStore+State.swift
+++ b/Projects/Feature/HomeFeature/Sources/Scene/Store/HomeStore+State.swift
@@ -10,6 +10,7 @@ extension HomeStore {
     struct State {
         var currentTime: Date = .init()
         var currentUserRole: UserRoleType = .member
+        var profileImageUrl: String? = ""
         var selfStudyInfo: (Int, Int) = (0, 0)
         var massageInfo: (Int, Int) = (0, 0)
         var selectedMealDate: Date = Date()
@@ -29,6 +30,7 @@ extension HomeStore {
     enum Mutation {
         case updateCurrentTime(Date)
         case updateCurrentUserRole(UserRoleType)
+        case updateProfileImage(String)
         case updateSelfStudyInfo((Int, Int))
         case updateMassageInfo((Int, Int))
         case updateSelectedMealDate(Date)
@@ -54,6 +56,9 @@ extension HomeStore {
 
         case let .updateCurrentUserRole(userRole):
             newState.currentUserRole = userRole
+
+        case let .updateProfileImage(profileImageUrl):
+            newState.profileImageUrl = profileImageUrl
 
         case let .updateSelfStudyInfo(selfStudyInfo):
             newState.selfStudyInfo = selfStudyInfo

--- a/Projects/Feature/HomeFeature/Tests/HomeFeatureTest.swift
+++ b/Projects/Feature/HomeFeature/Tests/HomeFeatureTest.swift
@@ -29,6 +29,7 @@ final class HomeFeatureTests: XCTestCase {
 
     override func setUp() {
         repeatableTimer = .init()
+        fetchProfileImageUseCase = .init()
         fetchSelfStudyInfoUseCase = .init()
         fetchMassageInfoUseCase = .init()
         fetchMealInfoUseCase = .init()

--- a/Projects/Feature/HomeFeature/Tests/HomeFeatureTest.swift
+++ b/Projects/Feature/HomeFeature/Tests/HomeFeatureTest.swift
@@ -11,6 +11,7 @@ import XCTest
 
 final class HomeFeatureTests: XCTestCase {
     var repeatableTimer: RepeatableTimerStub!
+    var fetchProfileImageUseCase: FetchProfileImageUseCaseSpy!
     var fetchSelfStudyInfoUseCase: FetchSelfStudyInfoUseCaseSpy!
     var fetchMassageInfoUseCase: FetchMassageInfoUseCaseSpy!
     var fetchMealInfoUseCase: FetchMealInfoUseCaseSpy!
@@ -42,6 +43,7 @@ final class HomeFeatureTests: XCTestCase {
         withdrawalUseCase = .init()
         sut = .init(
             repeatableTimer: repeatableTimer,
+            fetchProfileImageUseCase: fetchProfileImageUseCase,
             fetchSelfStudyInfoUseCase: fetchSelfStudyInfoUseCase,
             fetchMassageInfoUseCase: fetchMassageInfoUseCase,
             fetchMealInfoUseCase: fetchMealInfoUseCase,
@@ -60,6 +62,7 @@ final class HomeFeatureTests: XCTestCase {
 
     override func tearDown() {
         repeatableTimer = nil
+        fetchProfileImageUseCase = nil
         fetchSelfStudyInfoUseCase = nil
         fetchMassageInfoUseCase = nil
         fetchMealInfoUseCase = nil

--- a/Projects/Feature/MassageFeature/Demo/Sources/AppDelegate.swift
+++ b/Projects/Feature/MassageFeature/Demo/Sources/AppDelegate.swift
@@ -16,9 +16,9 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
         let fetchMassageRankListUseCase = FetchMassageRankListUseCaseSpy()
         fetchMassageRankListUseCase.fetchMassageRankListHandler = {
             [
-                .init(id: 1, rank: 1, stuNum: "1234", memberName: "대충이름", gender: .man),
-                .init(id: 2, rank: 2, stuNum: "1235", memberName: "대이충름", gender: .man),
-                .init(id: 3, rank: 3, stuNum: "1236", memberName: "이름대충", gender: .woman)
+                .init(id: 1, rank: 1, stuNum: "1234", memberName: "대충이름", gender: .man, profileImage: ""),
+                .init(id: 2, rank: 2, stuNum: "1235", memberName: "대이충름", gender: .man, profileImage: ""),
+                .init(id: 3, rank: 3, stuNum: "1236", memberName: "이름대충", gender: .woman, profileImage: "")
             ]
         }
         let store = MassageStore(

--- a/Projects/Feature/MassageFeature/Sources/Scene/View/MassageCell.swift
+++ b/Projects/Feature/MassageFeature/Sources/Scene/View/MassageCell.swift
@@ -12,7 +12,6 @@ final class MassageCell: BaseTableViewCell<MassageRankModel> {
     override func prepareForReuse() {
         super.prepareForReuse()
         appliedStudentCardView.cancelImageDownload()
-        guard model == nil else { return }
     }
 
     override func addView() {
@@ -43,7 +42,7 @@ final class MassageCell: BaseTableViewCell<MassageRankModel> {
                 gender: model.gender == .man ? .man : .woman,
                 stuNum: model.stuNum,
                 isChecked: false,
-                profileImage: ""
+                profileImage: model.profileImage
             )
         )
     }

--- a/Projects/Feature/MassageFeature/Sources/Scene/View/MassageCell.swift
+++ b/Projects/Feature/MassageFeature/Sources/Scene/View/MassageCell.swift
@@ -9,6 +9,12 @@ import UIKit
 final class MassageCell: BaseTableViewCell<MassageRankModel> {
     private let appliedStudentCardView = AppliedStudentCardView()
 
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        appliedStudentCardView.cancelImageDownload()
+        guard model == nil else { return }
+    }
+
     override func addView() {
         contentView.addSubviews {
             appliedStudentCardView
@@ -36,7 +42,8 @@ final class MassageCell: BaseTableViewCell<MassageRankModel> {
                 name: model.memberName,
                 gender: model.gender == .man ? .man : .woman,
                 stuNum: model.stuNum,
-                isChecked: false
+                isChecked: false,
+                profileImage: ""
             )
         )
     }

--- a/Projects/Feature/MassageFeature/Tests/MassageFeatureTest.swift
+++ b/Projects/Feature/MassageFeature/Tests/MassageFeatureTest.swift
@@ -28,7 +28,14 @@ final class MassageFeatureTests: XCTestCase {
         let expectation = XCTestExpectation(description: "Test_Fetch_Massage_Rank_List")
         expectation.expectedFulfillmentCount = 2
         let expectedMassageRankList = [
-            MassageRankModel(id: 1, rank: 1, stuNum: "2222", memberName: "익명", gender: .woman)
+            MassageRankModel(
+                id: 1,
+                rank: 1,
+                stuNum: "2222",
+                memberName: "익명",
+                gender: .woman,
+                profileImage: ""
+            )
         ]
         fetchMassageRankListUseCase.fetchMassageRankListHandler = { expectedMassageRankList }
 

--- a/Projects/Feature/SelfStudyFeature/Demo/Sources/AppDelegate.swift
+++ b/Projects/Feature/SelfStudyFeature/Demo/Sources/AppDelegate.swift
@@ -16,9 +16,33 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
         window = UIWindow(frame: UIScreen.main.bounds)
         let fetchSelfStudyRankListUseCase = FetchSelfStudyRankListUseCaseSpy()
         fetchSelfStudyRankListUseCase.fetchSelfStudyRankListReturn = [
-            .init(id: 1, rank: 1, stuNum: "3107", memberName: "김준", gender: .man, selfStudyCheck: false),
-            .init(id: 2, rank: 2, stuNum: "3216", memberName: "전승원", gender: .man, selfStudyCheck: true),
-            .init(id: 3, rank: 3, stuNum: "3111", memberName: "선민재", gender: .woman, selfStudyCheck: false)
+            .init(
+                id: 1,
+                rank: 1,
+                stuNum: "3107",
+                memberName: "김준",
+                gender: .man,
+                selfStudyCheck: false,
+                profileImage: ""
+            ),
+            .init(
+                id: 2,
+                rank: 2,
+                stuNum: "3216",
+                memberName: "전승원",
+                gender: .man,
+                selfStudyCheck: true,
+                profileImage: ""
+            ),
+            .init(
+                id: 3,
+                rank: 3,
+                stuNum: "3111",
+                memberName: "선민재",
+                gender: .woman,
+                selfStudyCheck: false,
+                profileImage: ""
+            )
         ]
         let loadCurrentUserRoleUseCase = LoadCurrentUserRoleUseCaseSpy()
         let checkSelfStudyMemberUseCase = CheckSelfStudyMemberUseCaseSpy()

--- a/Projects/Feature/SelfStudyFeature/Sources/Scene/SelfStudyStore.swift
+++ b/Projects/Feature/SelfStudyFeature/Sources/Scene/SelfStudyStore.swift
@@ -155,7 +155,7 @@ private extension SelfStudyStore {
                 memberName: $0.memberName,
                 gender: $0.gender,
                 selfStudyCheck: isChecked,
-                profileImage: $0.profileImage ?? ""
+                profileImage: $0.profileImage
             )
         }
     }

--- a/Projects/Feature/SelfStudyFeature/Sources/Scene/SelfStudyStore.swift
+++ b/Projects/Feature/SelfStudyFeature/Sources/Scene/SelfStudyStore.swift
@@ -154,7 +154,8 @@ private extension SelfStudyStore {
                 stuNum: $0.stuNum,
                 memberName: $0.memberName,
                 gender: $0.gender,
-                selfStudyCheck: isChecked
+                selfStudyCheck: isChecked,
+                profileImage: $0.profileImage ?? ""
             )
         }
     }

--- a/Projects/Feature/SelfStudyFeature/Sources/Scene/View/SelfStudyCell.swift
+++ b/Projects/Feature/SelfStudyFeature/Sources/Scene/View/SelfStudyCell.swift
@@ -3,6 +3,7 @@ import BaseFeature
 import Combine
 import DesignSystem
 import MSGLayout
+import Nuke
 import SelfStudyDomainInterface
 import UIKit
 
@@ -31,6 +32,7 @@ final class SelfStudyCell: BaseTableViewCell<SelfStudyRankModel> {
 
     override func prepareForReuse() {
         super.prepareForReuse()
+        appliedStudentCardView.cancelImageDownload()
         guard model == nil else { return }
         subscription.removeAll()
     }
@@ -69,7 +71,8 @@ final class SelfStudyCell: BaseTableViewCell<SelfStudyRankModel> {
                 name: model.memberName,
                 gender: model.gender == .man ? .man : .woman,
                 stuNum: model.stuNum,
-                isChecked: model.selfStudyCheck
+                isChecked: model.selfStudyCheck,
+                profileImage: model.profileImage ?? ""
             )
         )
         self.medalImageView.image = self.rankToImage(rank: model.rank)

--- a/Projects/Feature/SelfStudyFeature/Sources/Scene/View/SelfStudyCell.swift
+++ b/Projects/Feature/SelfStudyFeature/Sources/Scene/View/SelfStudyCell.swift
@@ -3,7 +3,6 @@ import BaseFeature
 import Combine
 import DesignSystem
 import MSGLayout
-import Nuke
 import SelfStudyDomainInterface
 import UIKit
 
@@ -72,7 +71,7 @@ final class SelfStudyCell: BaseTableViewCell<SelfStudyRankModel> {
                 gender: model.gender == .man ? .man : .woman,
                 stuNum: model.stuNum,
                 isChecked: model.selfStudyCheck,
-                profileImage: model.profileImage ?? ""
+                profileImage: model.profileImage
             )
         )
         self.medalImageView.image = self.rankToImage(rank: model.rank)

--- a/Projects/UserInterface/DesignSystem/Sources/CardView/AppliedStudentCardView.swift
+++ b/Projects/UserInterface/DesignSystem/Sources/CardView/AppliedStudentCardView.swift
@@ -99,10 +99,10 @@ public final class AppliedStudentCardView: UIView {
             priority: .high
         )
         
-        imageTask = Task {
+        imageTask = Task.detached {
             let image = try await ImagePipeline.shared.image(for: request)
             guard !Task.isCancelled else { return }
-            DispatchQueue.main.async {
+            await MainActor.run { 
                 self.userImageView.image = image
             }
         }

--- a/Projects/UserInterface/DesignSystem/Sources/CardView/AppliedStudentCardView.swift
+++ b/Projects/UserInterface/DesignSystem/Sources/CardView/AppliedStudentCardView.swift
@@ -1,5 +1,6 @@
 import Combine
 import MSGLayout
+import Nuke
 import UIKit
 
 public struct AppliedStudentViewModel: Equatable {
@@ -8,18 +9,27 @@ public struct AppliedStudentViewModel: Equatable {
     public let gender: Gender
     public let stuNum: String
     public let isChecked: Bool
+    public let profileImage: String?
 
     public enum Gender {
         case man
         case woman
     }
 
-    public init(rank: Int, name: String, gender: Gender, stuNum: String, isChecked: Bool) {
+    public init(
+        rank: Int,
+        name: String,
+        gender: Gender,
+        stuNum: String,
+        isChecked: Bool,
+        profileImage: String
+    ) {
         self.rank = rank
         self.name = name
         self.gender = gender
         self.stuNum = stuNum
         self.isChecked = isChecked
+        self.profileImage = profileImage
     }
 }
 
@@ -28,12 +38,12 @@ public protocol AppliedStudentCardViewActionProtocol {
 }
 
 public final class AppliedStudentCardView: UIView {
+    private var imageTask: Task<Void, Error>?
     private let rankLabel = DotoriLabel(textColor: .neutral(.n20), font: .caption)
     private let attendanceCheckBox = DotoriCheckBox()
         .set(\.isHidden, true)
     private let userImageView = DotoriIconView(
-        size: .custom(.init(width: 64, height: 64)),
-        image: .Dotori.personRectangle
+        size: .custom(.init(width: 64, height: 64))
     )
     private let nameLabel = DotoriLabel(textColor: .neutral(.n10), font: .body1)
     private let genderImageView = DotoriIconView(
@@ -67,16 +77,42 @@ public final class AppliedStudentCardView: UIView {
     public func updateContent(
         with viewModel: AppliedStudentViewModel
     ) {
-        rankLabel.text = "\(viewModel.rank)"
-        nameLabel.text = viewModel.name
-        genderImageView.image = (viewModel.gender == .man ? UIImage.Dotori.men : .Dotori.women)
+        self.rankLabel.text = "\(viewModel.rank)"
+        self.nameLabel.text = viewModel.name
+        self.genderImageView.image = (viewModel.gender == .man ? UIImage.Dotori.men : .Dotori.women)
             .withTintColor(.dotori(.neutral(.n10)), renderingMode: .alwaysOriginal)
-        stuNumLabel.text = viewModel.stuNum
-        attendanceCheckBox.isChecked = viewModel.isChecked
+        self.stuNumLabel.text = viewModel.stuNum
+        self.attendanceCheckBox.isChecked = viewModel.isChecked
+
+        guard let profileImageURL = viewModel.profileImage,
+              let imageURL = URL(string: profileImageURL)
+        else {
+            self.userImageView.image = .Dotori.personRectangle
+            return
+        }
+
+        let request = ImageRequest(
+            url: imageURL,
+            priority: .high,
+            options: [.reloadIgnoringCachedData]
+        )
+
+        imageTask = Task {
+            let image = try await ImagePipeline.shared.image(for: request)
+            guard !Task.isCancelled else { return }
+            DispatchQueue.main.async {
+                self.userImageView.image = image
+            }
+        }
     }
 
     public func setIsHiddenAttendanceCheckBox(_ isHidden: Bool) {
         attendanceCheckBox.isHidden = isHidden
+    }
+
+    public func cancelImageDownload() {
+        imageTask?.cancel()
+        imageTask = nil
     }
 }
 
@@ -103,7 +139,8 @@ private extension AppliedStudentCardView {
                 .top(.toSuperview(), .equal(28))
                 .bottom(.toSuperview(), .equal(-28))
         }
-
+        userImageView.cornerRadius = 8
+        userImageView.clipsToBounds = true
         self.backgroundColor = .dotori(.background(.card))
         self.cornerRadius = 16
         DotoriShadow.cardShadow(card: self)

--- a/Projects/UserInterface/DesignSystem/Sources/CardView/AppliedStudentCardView.swift
+++ b/Projects/UserInterface/DesignSystem/Sources/CardView/AppliedStudentCardView.swift
@@ -94,8 +94,7 @@ public final class AppliedStudentCardView: UIView {
 
         let request = ImageRequest(
             url: imageURL,
-            priority: .high,
-            options: [.reloadIgnoringCachedData]
+            priority: .high
         )
 
         imageTask = Task {

--- a/Projects/UserInterface/DesignSystem/Sources/CardView/AppliedStudentCardView.swift
+++ b/Projects/UserInterface/DesignSystem/Sources/CardView/AppliedStudentCardView.swift
@@ -10,12 +10,12 @@ public struct AppliedStudentViewModel: Equatable {
     public let stuNum: String
     public let isChecked: Bool
     public let profileImage: String?
-    
+
     public enum Gender {
         case man
         case woman
     }
-    
+
     public init(
         rank: Int,
         name: String,
@@ -46,8 +46,8 @@ public final class AppliedStudentCardView: UIView {
         size: .custom(.init(width: 64, height: 64)),
         image: .Dotori.personRectangle
     )
-        .set(\.cornerRadius, 8)
-        .set(\.clipsToBounds, true)
+    .set(\.cornerRadius, 8)
+    .set(\.clipsToBounds, true)
     private let nameLabel = DotoriLabel(textColor: .neutral(.n10), font: .body1)
     private let genderImageView = DotoriIconView(
         size: .custom(.init(width: 16, height: 16)),
@@ -56,27 +56,27 @@ public final class AppliedStudentCardView: UIView {
     private let stuNumLabel = DotoriLabel(textColor: .neutral(.n20), font: .caption)
     private lazy var profileStackView = VStackView(spacing: 8) {
         userImageView
-        
+
         HStackView(spacing: 2) {
             nameLabel
-            
+
             genderImageView
         }
         .alignment(.center)
-        
+
         stuNumLabel
     }.alignment(.center)
-    
+
     public init() {
         super.init(frame: .zero)
         configureView()
     }
-    
+
     @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     public func updateContent(
         with viewModel: AppliedStudentViewModel
     ) {
@@ -86,32 +86,32 @@ public final class AppliedStudentCardView: UIView {
             .withTintColor(.dotori(.neutral(.n10)), renderingMode: .alwaysOriginal)
         self.stuNumLabel.text = viewModel.stuNum
         self.attendanceCheckBox.isChecked = viewModel.isChecked
-        
+
         guard let profileImageURL = viewModel.profileImage,
               let imageURL = URL(string: profileImageURL)
         else {
             self.userImageView.image = .Dotori.personRectangle
             return
         }
-        
+
         let request = ImageRequest(
             url: imageURL,
             priority: .high
         )
-        
+
         imageTask = Task.detached {
             let image = try await ImagePipeline.shared.image(for: request)
             guard !Task.isCancelled else { return }
-            await MainActor.run { 
+            await MainActor.run {
                 self.userImageView.image = image
             }
         }
     }
-    
+
     public func setIsHiddenAttendanceCheckBox(_ isHidden: Bool) {
         attendanceCheckBox.isHidden = isHidden
     }
-    
+
     public func cancelImageDownload() {
         imageTask?.cancel()
         imageTask = nil
@@ -125,17 +125,17 @@ private extension AppliedStudentCardView {
             attendanceCheckBox
             profileStackView
         }
-        
+
         MSGLayout.buildLayout {
             rankLabel.layout
                 .top(.toSuperview(), .equal(12))
                 .leading(.toSuperview(), .equal(16))
-            
+
             attendanceCheckBox.layout
                 .top(.toSuperview(), .equal(12))
                 .trailing(.toSuperview(), .equal(-12))
                 .size(24)
-            
+
             profileStackView.layout
                 .centerX(.toSuperview())
                 .top(.toSuperview(), .equal(28))

--- a/Projects/UserInterface/DesignSystem/Sources/CardView/AppliedStudentCardView.swift
+++ b/Projects/UserInterface/DesignSystem/Sources/CardView/AppliedStudentCardView.swift
@@ -10,12 +10,12 @@ public struct AppliedStudentViewModel: Equatable {
     public let stuNum: String
     public let isChecked: Bool
     public let profileImage: String?
-
+    
     public enum Gender {
         case man
         case woman
     }
-
+    
     public init(
         rank: Int,
         name: String,
@@ -46,6 +46,8 @@ public final class AppliedStudentCardView: UIView {
         size: .custom(.init(width: 64, height: 64)),
         image: .Dotori.personRectangle
     )
+        .set(\.cornerRadius, 8)
+        .set(\.clipsToBounds, true)
     private let nameLabel = DotoriLabel(textColor: .neutral(.n10), font: .body1)
     private let genderImageView = DotoriIconView(
         size: .custom(.init(width: 16, height: 16)),
@@ -54,27 +56,27 @@ public final class AppliedStudentCardView: UIView {
     private let stuNumLabel = DotoriLabel(textColor: .neutral(.n20), font: .caption)
     private lazy var profileStackView = VStackView(spacing: 8) {
         userImageView
-
+        
         HStackView(spacing: 2) {
             nameLabel
-
+            
             genderImageView
         }
         .alignment(.center)
-
+        
         stuNumLabel
     }.alignment(.center)
-
+    
     public init() {
         super.init(frame: .zero)
         configureView()
     }
-
+    
     @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-
+    
     public func updateContent(
         with viewModel: AppliedStudentViewModel
     ) {
@@ -84,19 +86,19 @@ public final class AppliedStudentCardView: UIView {
             .withTintColor(.dotori(.neutral(.n10)), renderingMode: .alwaysOriginal)
         self.stuNumLabel.text = viewModel.stuNum
         self.attendanceCheckBox.isChecked = viewModel.isChecked
-
+        
         guard let profileImageURL = viewModel.profileImage,
               let imageURL = URL(string: profileImageURL)
         else {
             self.userImageView.image = .Dotori.personRectangle
             return
         }
-
+        
         let request = ImageRequest(
             url: imageURL,
             priority: .high
         )
-
+        
         imageTask = Task {
             let image = try await ImagePipeline.shared.image(for: request)
             guard !Task.isCancelled else { return }
@@ -105,11 +107,11 @@ public final class AppliedStudentCardView: UIView {
             }
         }
     }
-
+    
     public func setIsHiddenAttendanceCheckBox(_ isHidden: Bool) {
         attendanceCheckBox.isHidden = isHidden
     }
-
+    
     public func cancelImageDownload() {
         imageTask?.cancel()
         imageTask = nil
@@ -123,24 +125,22 @@ private extension AppliedStudentCardView {
             attendanceCheckBox
             profileStackView
         }
-
+        
         MSGLayout.buildLayout {
             rankLabel.layout
                 .top(.toSuperview(), .equal(12))
                 .leading(.toSuperview(), .equal(16))
-
+            
             attendanceCheckBox.layout
                 .top(.toSuperview(), .equal(12))
                 .trailing(.toSuperview(), .equal(-12))
                 .size(24)
-
+            
             profileStackView.layout
                 .centerX(.toSuperview())
                 .top(.toSuperview(), .equal(28))
                 .bottom(.toSuperview(), .equal(-28))
         }
-        userImageView.cornerRadius = 8
-        userImageView.clipsToBounds = true
         self.backgroundColor = .dotori(.background(.card))
         self.cornerRadius = 16
         DotoriShadow.cardShadow(card: self)

--- a/Projects/UserInterface/DesignSystem/Sources/CardView/AppliedStudentCardView.swift
+++ b/Projects/UserInterface/DesignSystem/Sources/CardView/AppliedStudentCardView.swift
@@ -22,7 +22,7 @@ public struct AppliedStudentViewModel: Equatable {
         gender: Gender,
         stuNum: String,
         isChecked: Bool,
-        profileImage: String
+        profileImage: String?
     ) {
         self.rank = rank
         self.name = name
@@ -43,7 +43,8 @@ public final class AppliedStudentCardView: UIView {
     private let attendanceCheckBox = DotoriCheckBox()
         .set(\.isHidden, true)
     private let userImageView = DotoriIconView(
-        size: .custom(.init(width: 64, height: 64))
+        size: .custom(.init(width: 64, height: 64)),
+        image: .Dotori.personRectangle
     )
     private let nameLabel = DotoriLabel(textColor: .neutral(.n10), font: .body1)
     private let genderImageView = DotoriIconView(


### PR DESCRIPTION
## 💡 개요
자습신청, 안마의자 신청 페이지에서 프로필 이미지가 보일 수 있게 수정했습니다.

## 📃 작업내용
자습신청, 안마의자 신청 페이지에서 프로필 이미지가 보일 수 있게 수정

