### PR TITLE
🔀 :: [#233] runner 환경 macos14 업그레이드

### DIFF
--- a/.github/workflows/AppStore.yml
+++ b/.github/workflows/AppStore.yml
@@ -42,7 +42,7 @@ env:
 jobs:
   distribute:
     name: 🚀 App Store Submission
-    runs-on: macos-latest
+    runs-on: macos-14
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
## 💡 개요
개발할때부터 xcode 15로 하는만큼 GitHub Action workflow의 runner들도 macos 14 이상으로는 돌여야할거같아요.

## 📃 작업내용
AppStore workflow의 runner환경을 macos-14로 변경했어요.
